### PR TITLE
Allowing to use provisioned throughput for CosmosDB 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -78,7 +78,7 @@ NOTE: For the best scalability, it is recommended to configure your CosmosDB pro
 
 2. *cosmosDBAuthKeySettingKey* - The appsetting key name which points to a CosmosDB auth key
 
-3. *offerThroughput* - The offer throughput provisioned for a collection in measurement of Requests-per-Unit in the Azure DocumentDB database service. If the collection provided doesn't exist, the provider will create a collection with this offerThroughput.
+3. *offerThroughput* - The offer throughput provisioned for a collection in measurement of Requests-per-Unit in the Azure DocumentDB database service. If the collection provided doesn't exist, the provider will create a collection with this offerThroughput. If the database already exists and has provisioned throughput, this value can be set to "0" to use it.
 
 4. *connectionMode* - Direct | Gateway
 

--- a/src/CosmosDBSessionStateProviderAsync/CosmosDBSessionStateProviderAsync.cs
+++ b/src/CosmosDBSessionStateProviderAsync/CosmosDBSessionStateProviderAsync.cs
@@ -1037,7 +1037,7 @@ namespace Microsoft.AspNet.SessionState
                     if (!containsWildcard)
                     {
                         dc.IndexingPolicy = s_indexNone;
-                        await s_client.ReplaceDocumentCollectionAsync(DocumentCollectionUri, dc, new RequestOptions { OfferThroughput = s_offerThroughput });
+                        await s_client.ReplaceDocumentCollectionAsync(DocumentCollectionUri, dc, GetRequestOptions());
                     }
                 }
             }
@@ -1064,7 +1064,7 @@ namespace Microsoft.AspNet.SessionState
                     await s_client.CreateDocumentCollectionAsync(
                         UriFactory.CreateDatabaseUri(s_dbId),
                         docCollection,
-                        new RequestOptions { OfferThroughput = s_offerThroughput });
+                        GetRequestOptions());
                 }
                 else
                 {
@@ -1072,6 +1072,11 @@ namespace Microsoft.AspNet.SessionState
                 }
             }
         }
+
+	    private static RequestOptions GetRequestOptions()
+	    {
+		    return s_offerThroughput == 0 ? null : new RequestOptions {OfferThroughput = s_offerThroughput};
+	    }
 
         private static bool PartitionEnabled {
             get {


### PR DESCRIPTION
Allowing to use provisioned throughput by setting offerThroughput value to "0".

This allows to have a fixed CosmosDB cost for deploying multiple copies of an application, all using the same Cosmos DB with provisioned and shared throughput, while letting configure individual applications to store sessions in their own collections, which is helpful for diagnostic and cleanup purposes.