### PR TITLE
Feature/set application name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,8 @@ Before you can specify one of these custom providers. You need to remove the exi
 ```
     <sessionState cookieless="false" regenerateExpiredSessionId="true" mode="Custom" customProvider="SqlSessionStateProviderAsync">
       <providers>
-        <add name="SqlSessionStateProviderAsync" connectionStringName="DefaultConnection" UseInMemoryTable="[true|false]" MaxRetryNumber="[int]" RetryInterval="[int]"
+        <add name="SqlSessionStateProviderAsync" connectionStringName="DefaultConnection" 
+             UseInMemoryTable="[true|false]" MaxRetryNumber="[int]" RetryInterval="[int]" ApplicationName="[string]"
           type="Microsoft.AspNet.SessionState.SqlSessionStateProviderAsync, Microsoft.AspNet.SessionState.SqlSessionStateProviderAsync, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
       </providers>
 ```
@@ -55,6 +56,8 @@ Before you can specify one of these custom providers. You need to remove the exi
 2. *MaxRetryNumber* - The maximum number of retrying executing sql query to read/write sessionstate data from/to Sql server. The default value is 10.
 
 3. *RetryInterval* - The interval between the retry of executing sql query. The default value is 0.001 sec for in-memorytable mode. Otherwise the default value is 1 sec.
+
+4. *ApplicationName* - If an application runs on multiple nodes, the same session is used if and only if the application name is identically specified on all nodes.
 
 + #### Microsoft.AspNet.SessionState.CosmosDBSessionStateProviderAsync
 

--- a/src/SqlSessionStateProviderAsync/SqlSessionStateProviderAsync.cs
+++ b/src/SqlSessionStateProviderAsync/SqlSessionStateProviderAsync.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNet.SessionState
         private const string INMEMORY_TABLE_CONFIGURATION_NAME = "UseInMemoryTable";
         private const string MAX_RETRY_NUMBER_CONFIGURATION_NAME = "MaxRetryNumber";
         private const string RETRY_INTERVAL_CONFIGURATION_NAME = "RetryInterval";
+        private const string APPLICATION_NAME_CONFIGURATION_NAME = "ApplicationName";
         private const string CONNECTIONSTRING_NAME_CONFIGURATION_NAME = "connectionStringName";
         private const string SESSIONSTATE_SECTION_PATH = "system.web/sessionState";
         private const double SessionExpiresFrequencyCheckIntervalTicks = 30 * TimeSpan.TicksPerSecond;
@@ -90,7 +91,7 @@ namespace Microsoft.AspNet.SessionState
                             s_sqlSessionStateRepository.CreateSessionStateTable();
                         }
 
-                        var appId = AppId ?? HttpRuntime.AppDomainAppId;
+                        var appId = GetApplicationId(config);
                         Debug.Assert(appId != null);
                         s_appSuffix = appId.GetHashCode().ToString("X8", CultureInfo.InvariantCulture);
 
@@ -160,6 +161,12 @@ namespace Microsoft.AspNet.SessionState
                 return retryInterval;
             }
             return null;
+        }
+
+        private string GetApplicationId(NameValueCollection config)
+        {
+            var val = config[APPLICATION_NAME_CONFIGURATION_NAME];
+            return (!string.IsNullOrWhiteSpace(val) ? val : AppId) ?? HttpRuntime.AppDomainAppId;
         }
 
         /// <summary>


### PR DESCRIPTION
New parameter ApplicationName for SqlSessionStateProviderAsync

If an application runs on multiple nodes, the same session is used if the application name is identically specified on all nodes. The value defaults to HttpRuntime.AppDomainAppId if unspecified.

The parameter is specified in the web.config as following:
`<add name="SqlSessionStateProviderAsync" connectionStringName="DefaultConnection" 
   UseInMemoryTable="[true|false]" MaxRetryNumber="[int]" RetryInterval="[int]" ApplicationName="[string]" type="Microsoft.AspNet.SessionState.SqlSessionStateProviderAsync,  ..."/>
`