### PR TITLE
Fix CosmosDB stored procedures to use requestOptions in queryDocuments

### DIFF
--- a/src/CosmosDBSessionStateProviderAsync/CosmosDBSessionStateProviderAsync.cs
+++ b/src/CosmosDBSessionStateProviderAsync/CosmosDBSessionStateProviderAsync.cs
@@ -133,7 +133,7 @@ namespace Microsoft.AspNet.SessionState
                 function tryGetStateItem(continuation) {
                     var requestOptions = { continuation: continuation};
                     var query = 'select * from root r where r.id = ""' + sessionId + '""';
-                    var isAccepted = collection.queryDocuments(collectionLink, query, continuation,
+                    var isAccepted = collection.queryDocuments(collectionLink, query, requestOptions,
                         function(err, documents, responseOptions) {
                             if (err)
                             {
@@ -351,7 +351,7 @@ namespace Microsoft.AspNet.SessionState
                 function TryRemoveStateItem(continuation) {
                     var requestOptions = { continuation: continuation};
                     var query = 'select * from root r where r.id = ""' + sessionId + '"" and r.lockCookie = ' + lockCookie;
-                    var isAccepted = collection.queryDocuments(collectionLink, query, continuation,
+                    var isAccepted = collection.queryDocuments(collectionLink, query, requestOptions,
                         function(err, documents, responseOptions) {
                     if (err)
                     {


### PR DESCRIPTION
It appeared to be a copy-paste error. According to the cosmosdb api guide, queryDocument should be accepting a FeedOptions object, not just the continuation string.
https://azure.github.io/azure-cosmosdb-js-server/Collection.html

