### PR TITLE
Eliminate closures

### DIFF
--- a/src/SessionStateModule/SessionStateModuleAsync.cs
+++ b/src/SessionStateModule/SessionStateModuleAsync.cs
@@ -282,8 +282,7 @@ namespace Microsoft.AspNet.SessionState
 
         private IAsyncResult BeginAcquireState(object source, EventArgs e, AsyncCallback cb, object extraData)
         {
-            HttpContext rqContext = ((HttpApplication)source).Context;
-            return TaskAsyncHelper.BeginTask(() => AcquireStateAsync(rqContext), cb, extraData);
+            return TaskAsyncHelper.BeginTask((HttpApplication)source, app => AcquireStateAsync(app), cb, extraData);
         }
 
         private void EndAcquireState(IAsyncResult result)
@@ -293,8 +292,7 @@ namespace Microsoft.AspNet.SessionState
 
         private IAsyncResult BeginOnEndRequest(object source, EventArgs e, AsyncCallback cb, object extraData)
         {
-            var app = (HttpApplication)source;
-            return TaskAsyncHelper.BeginTask(() => OnEndRequestAsync(app), cb, extraData);
+            return TaskAsyncHelper.BeginTask((HttpApplication)source, app => OnEndRequestAsync(app), cb, extraData);
         }
 
         private void EndOnEndRequest(IAsyncResult result)
@@ -304,8 +302,7 @@ namespace Microsoft.AspNet.SessionState
 
         private IAsyncResult BeginOnReleaseState(object source, EventArgs e, AsyncCallback cb, object extraData)
         {
-            var app = (HttpApplication)source;
-            return TaskAsyncHelper.BeginTask(() => ReleaseStateAsync(app), cb, extraData);
+            return TaskAsyncHelper.BeginTask((HttpApplication)source, app => ReleaseStateAsync(app), cb, extraData);
         }
 
         private void EndOnReleaseState(IAsyncResult result)
@@ -380,8 +377,9 @@ namespace Microsoft.AspNet.SessionState
             RaiseOnStart(e);
         }
 
-        private async Task AcquireStateAsync(HttpContext context)
+        private async Task AcquireStateAsync(HttpApplication app)
         {
+            HttpContext context = app.Context;
             _acquireCalled = true;
             _releaseCalled = false;
             ResetPerRequestFields();

--- a/src/SessionStateModule/TaskAsyncHelper.cs
+++ b/src/SessionStateModule/TaskAsyncHelper.cs
@@ -6,14 +6,15 @@ namespace Microsoft.AspNet.SessionState
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using System.Web;
 
     static class TaskAsyncHelper
     {
         private static readonly Task CompletedTask = Task.FromResult<object>(null);
 
-        public static IAsyncResult BeginTask(Func<Task> taskFunc, AsyncCallback callback, object state)
+        public static IAsyncResult BeginTask(HttpApplication app, Func<HttpApplication, Task> taskFunc, AsyncCallback callback, object state)
         {
-            Task task = taskFunc();
+            Task task = taskFunc(app);
             if (task == null)
             {
                 // Something went wrong - let our caller handle it.


### PR DESCRIPTION
Subscription of asynchronous events from `SessionStateModuleAsync` close over the event sender.

Adding the `HttpApplication` to the invocation avoids the closure.