### PR TITLE
Update Cosmos DB SDK version to recommended minimum version or higher

### DIFF
--- a/src/CosmosDBSessionStateProviderAsync/Microsoft.AspNet.SessionState.CosmosDBSessionStateProviderAsync.csproj
+++ b/src/CosmosDBSessionStateProviderAsync/Microsoft.AspNet.SessionState.CosmosDBSessionStateProviderAsync.csproj
@@ -89,7 +89,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos">
-      <Version>3.23.0</Version>
+      <Version>3.31.2</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Fix references to an older version of the Cosmos DB SDK than recommended.

>The minimum recommended version is [3.31.0](https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/changelog.md#3.31.0).

https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/changelog.md