### PR TITLE
Add 'skipKeepAliveWhenUnused' to reduce unneeded traffic.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,7 @@ Information on contributing to this repo is in the [Contributing Guide](CONTRIBU
 ```xml
   <sessionState cookieless="false" regenerateExpiredSessionId="true" mode="Custom" customProvider="YourProviderName">
     <providers>
-      <add name="YourProviderName" [providerOptions] type="Provider, ProviderAssembly, Version=, Culture=neutral, PublicKeyToken=" />
+      <add name="YourProviderName" skipKeepAliveWhenUnused="false" [providerOptions] type="Provider, ProviderAssembly, Version=, Culture=neutral, PublicKeyToken=" />
     </providers>
   </sessionState>
 ```
@@ -46,6 +46,7 @@ The specific settings available for the new session state module and providers a
     
     > The mechanics of nuget package upgrade results in removing old elements and re-adding the boiler-plate elements in configuration. To restore In-Memory functionality, set 'RepositoryType' to `InMemory`. To continue using an existing non-memory-optimized table without stored procedures, set 'RespositoryType' to `FrameworkCompat`. The recommendation is to update to the new table schema and use stored procedures with `SqlServer`, but this will ignore existing sessions in previously existing tables.
   * Moved to use `Microsoft.Data.SqlClient` instead of old `System.Data.SqlClient`. This allows for more modern features such as Token Authorization.
+  * Added `skipKeepAliveWhenUnused` to all providers. This setting will skip the call to update expiration time on requests that did not read or write session state. This is setting is used at the module level, and is thus exists on all providers. The default is "false" to maintain compatibility. But certain applications (like MVC) where there can be an abundance of requests processed that never even look at session state could benefit from setting this to "true" to reduce the use of and contention within the session state store. Setting this to "true" does mean that a session needs to be used (not necessarily updated, but at least requested/queried) to stay alive.
   * The Sql provider's `UseInMemoryTable` is deprecated. It will continue to be respected in the absence of `RepositoryType`, but is overridden by that setting if given.
   * Sql provider `SessionTableName` - A new setting that allows users to target a specific table in their database rather than being forced to use the default table names.
   * CosmosDB `collectionId` is now `containerId` in keeping with the updated terminology from the CosmosDB offering. Please use the updated parameter name when configuring your provider. (The old name will continue to work just the same.)

--- a/docs/CosmosDBSessionStateProviderAsync.md
+++ b/docs/CosmosDBSessionStateProviderAsync.md
@@ -8,7 +8,7 @@ Then, register your new provider like so:
   <sessionState cookieless="false" regenerateExpiredSessionId="true" mode="Custom" customProvider="CosmosDBSessionStateProviderAsync">
     <providers>
       <add name="CosmosDBSessionStateProviderAsync" cosmosDBEndPointSettingKey="cosmosDBEndPointSetting" cosmosDBAuthKeySettingKey="cosmosDBAuthKeySetting"
-          databaseId="[DataBaseId]" collectionId="[CollectionId]" offerThroughput="5000" connectionMode="Direct" requestTimeout="5"
+          databaseId="[DataBaseId]" collectionId="[CollectionId]" offerThroughput="5000" connectionMode="Direct" requestTimeout="5" skipKeepAliveWhenUnused="false"
           maxConnectionLimit="50" maxRetryAttemptsOnThrottledRequests="10" maxRetryWaitTimeInSeconds="10" consistencyLevel="Session" preferredLocations=""
           type="Microsoft.AspNet.SessionState.CosmosDBSessionStateProviderAsync, Microsoft.AspNet.SessionState.CosmosDBSessionStateProviderAsync, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
     </providers>
@@ -28,12 +28,14 @@ Then, register your new provider like so:
 
 5. *requestTimeout* - The request timeout in seconds when connecting to the Azure DocumentDB database service.
 
-6. *maxConnectionLimit* - maximum number of concurrent connections allowed for the target service endpoint in the Azure DocumentDB database service.
+6. *skipKeepAliveWhenUnused* - This setting will skip the call to update expiration time on requests that did not read or write session state. The default is "false" to maintain compatibility with previous behavior. But certain applications (like MVC) where there can be an abundance of requests processed that never even look at session state could benefit from setting this to "true" to reduce the use of and contention within the session state store. Setting this to "true" does mean that a session needs to be used (not necessarily updated, but at least requested/queried) to stay alive.
 
-7. *maxRetryAttemptsOnThrottledRequests* - the maximum number of retries in the case where the request fails because the Azure DocumentDB database service has applied rate limiting on the client.
+7. *maxConnectionLimit* - maximum number of concurrent connections allowed for the target service endpoint in the Azure DocumentDB database service.
 
-8. *maxRetryWaitTimeInSeconds* - The maximum retry time in seconds for the Azure DocumentDB database service.
+8. *maxRetryAttemptsOnThrottledRequests* - the maximum number of retries in the case where the request fails because the Azure DocumentDB database service has applied rate limiting on the client.
 
-9. *consistencyLevel* - The [Consistency Level](https://learn.microsoft.com/en-us/azure/cosmos-db/consistency-levels) to use with the CosmosClient. Default is the Cosmos SDK default, which is currently 'Session'.
+9. *maxRetryWaitTimeInSeconds* - The maximum retry time in seconds for the Azure DocumentDB database service.
 
-10. *preferredLocations* - Sets the preferred locations(regions) for geo-replicated database accounts in the Azure DocumentDB database service. Use ';' to split multiple locations. e.g. "East US;South Central US;North Europe"
+10. *consistencyLevel* - The [Consistency Level](https://learn.microsoft.com/en-us/azure/cosmos-db/consistency-levels) to use with the CosmosClient. Default is the Cosmos SDK default, which is currently 'Session'.
+
+11. *preferredLocations* - Sets the preferred locations(regions) for geo-replicated database accounts in the Azure DocumentDB database service. Use ';' to split multiple locations. e.g. "East US;South Central US;North Europe"

--- a/docs/SqlSessionStateProviderAsync.md
+++ b/docs/SqlSessionStateProviderAsync.md
@@ -9,7 +9,7 @@ Then, register your new provider like so:
     <providers>
       <add name="SqlSessionStateProviderAsync" connectionStringName="DefaultConnection" SessionTableName="[string]"
           RepositoryType="[SqlServer|InMemory|InMemoryDurable|FrameworkCompat]"
-          MaxRetryNumber="[int]" RetryInterval="[int]"
+          MaxRetryNumber="[int]" RetryInterval="[int]" skipKeepAliveWhenUnused="false"
           type="Microsoft.AspNet.SessionState.SqlSessionStateProviderAsync, Microsoft.AspNet.SessionState.SqlSessionStateProviderAsync, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
     </providers>
   </sessionState>
@@ -42,4 +42,6 @@ The old in-box SQL provider allowed for applications to choose between three dat
 
 4. *RetryInterval* - The interval between the retry of executing sql query. The default value is 0.001 sec for in-memorytable mode. Otherwise the default value is 1 sec.
 
-5. **[Deprecated]** *UseInMemoryTable* - In the absence of a value for `RepositoryType`, this setting will be used to determine whether to use Sql server 2016 In-Memory OLTP for sessionstate. However, if `RepositoryType` is specified, that setting takes priority. You can find more details about using In-memory table for sessionstate [on this blog](https://blogs.msdn.microsoft.com/sqlcat/2016/10/26/how-bwin-is-using-sql-server-2016-in-memory-oltp-to-achieve-unprecedented-performance-and-scale/).
+5. *skipKeepAliveWhenUnused* - This setting will skip the call to update expiration time on requests that did not read or write session state. The default is "false" to maintain compatibility with previous behavior. But certain applications (like MVC) where there can be an abundance of requests processed that never even look at session state could benefit from setting this to "true" to reduce the use of and contention within the session state store. Setting this to "true" does mean that a session needs to be used (not necessarily updated, but at least requested/queried) to stay alive.
+
+6. **[Deprecated]** *UseInMemoryTable* - In the absence of a value for `RepositoryType`, this setting will be used to determine whether to use Sql server 2016 In-Memory OLTP for sessionstate. However, if `RepositoryType` is specified, that setting takes priority. You can find more details about using In-memory table for sessionstate [on this blog](https://blogs.msdn.microsoft.com/sqlcat/2016/10/26/how-bwin-is-using-sql-server-2016-in-memory-oltp-to-achieve-unprecedented-performance-and-scale/).

--- a/src/SessionStateModule/Resources/SR.Designer.cs
+++ b/src/SessionStateModule/Resources/SR.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.SessionState.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SR {
@@ -70,6 +70,15 @@ namespace Microsoft.AspNet.SessionState.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value for the &apos;{0}&apos; option on provider name &apos;{1}&apos; is invalid..
+        /// </summary>
+        internal static string Invalid_provider_option {
+            get {
+                return ResourceManager.GetString("Invalid_provider_option", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The custom session state store provider name &apos;{0}&apos; is invalid..
         /// </summary>
         internal static string Invalid_session_custom_provider {
@@ -88,7 +97,7 @@ namespace Microsoft.AspNet.SessionState.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SessionStateAsync module only supports InProce and Custom mode..
+        ///   Looks up a localized string similar to SessionStateAsync module only supports InProc and Custom mode..
         /// </summary>
         internal static string Not_Support_SessionState_Mode {
             get {

--- a/src/SessionStateModule/Resources/SR.resx
+++ b/src/SessionStateModule/Resources/SR.resx
@@ -120,6 +120,9 @@
   <data name="Error_Occured_Reading_Config_Secion" xml:space="preserve">
     <value>Error occured when reading config secion '{0}'.</value>
   </data>
+  <data name="Invalid_provider_option" xml:space="preserve">
+    <value>The value for the '{0}' option on provider name '{1}' is invalid.</value>
+  </data>
   <data name="Invalid_session_custom_provider" xml:space="preserve">
     <value>The custom session state store provider name '{0}' is invalid.</value>
   </data>

--- a/src/SessionStateModule/SessionStateModuleAsync.cs
+++ b/src/SessionStateModule/SessionStateModuleAsync.cs
@@ -406,7 +406,7 @@ namespace Microsoft.AspNet.SessionState
             _rqId = _idManager.GetSessionID(context);
             if (!_rqRequiresState)
             {
-                if (_rqId != null)
+                if (_rqId != null && !_store.SkipKeepAliveWhenUnused)
                 {
                     // Still need to update the sliding timeout to keep session alive.
                     // There is a plan to skip this for perf reason.  But it was postponed to

--- a/src/SessionStateModule/SessionStateStoreProviderAsyncBase.cs
+++ b/src/SessionStateModule/SessionStateStoreProviderAsyncBase.cs
@@ -3,7 +3,10 @@
 
 namespace Microsoft.AspNet.SessionState
 {
+    using Microsoft.AspNet.SessionState.Resources;
     using System;
+    using System.Collections.Specialized;
+    using System.Configuration;
     using System.Configuration.Provider;
     using System.Threading;
     using System.Threading.Tasks;
@@ -192,5 +195,24 @@ namespace Microsoft.AspNet.SessionState
         /// <param name="expireCallback"></param>
         /// <returns></returns>
         public abstract bool SetItemExpireCallback(SessionStateItemExpireCallback expireCallback);
+
+        /// <inheritdoc />
+        public override void Initialize(string name, NameValueCollection config)
+        {
+            base.Initialize(name, config);
+
+            // This is really a module-level setting, but it can't be specified within the rigid typed xml structure of the session-state module.
+            // So we have inserted this setting here and it will apply to all providers that this async module can use.
+
+            // skipKeepAliveWhenUnused
+            var skipKA = config["skipKeepAliveWhenUnused"];
+            if (skipKA != null && !bool.TryParse(skipKA, out _skipKeepAliveWhenUnused))
+            {
+                throw new ConfigurationErrorsException(string.Format(SR.Invalid_provider_option, "skipKeepAliveWhenUnused", name));
+            }
+        }
+
+        private bool _skipKeepAliveWhenUnused = false;
+        internal bool SkipKeepAliveWhenUnused { get { return _skipKeepAliveWhenUnused; } }
     }
 }


### PR DESCRIPTION
This setting will skip the call to update expiration time on requests that did not read or write session state. This is setting is used at the module level, and is thus exists on all providers. The default is "false" to maintain compatibility. But certain applications (like MVC) where there can be an abundance of requests processed that never even look at session state could benefit from setting this to "true" to reduce the use of and contention within the session state store. Setting this to "true" does mean that a session needs to be used (not necessarily updated, but at least requested/queried) to stay alive.