### PR TITLE
Existing record is ok when creating uninitialized state item.

### DIFF
--- a/test/Microsoft.AspNet.SessionState.CosmosDBSessionStateProviderAsync.Test/CosmosDBSessionStateProviderAsyncTest.cs
+++ b/test/Microsoft.AspNet.SessionState.CosmosDBSessionStateProviderAsync.Test/CosmosDBSessionStateProviderAsyncTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.SessionState.CosmosDBSessionStateAsyncProvider.Test
 
     public class CosmosDBSessionStateProviderAsyncTest
     {
-        private const string CreateSessionStateItemSPID = "CreateSessionStateItem";
+        private const string CreateSessionStateItemSPID = "CreateSessionStateItem2";
         private const string GetStateItemSPID = "GetStateItem2";
         private const string GetStateItemExclusiveSPID = "GetStateItemExclusive";
         private const string ReleaseItemExclusiveSPID = "ReleaseItemExclusive";


### PR DESCRIPTION
When we call CreateSessionStateItem to create an uninitialized state item, we do so solely to ensure the item exists so future calls to GetStateItem can successfully take a lock on it. It does not really matter what the contents of the item are (although the potential race condition here has two separate requests racing to create an uninitialized item, so the already existing item should also be "uninitialized"... but it doesn't really matter because we don't care what the contents are when we return, so long as it exists and we can lock it and overwrite it later.)