### PR TITLE
Thread-safe Item Collections for Concurrent mode

### DIFF
--- a/src/SessionStateModule/InProcSessionStateStoreAsync.cs
+++ b/src/SessionStateModule/InProcSessionStateStoreAsync.cs
@@ -437,7 +437,7 @@ namespace Microsoft.AspNet.SessionState
         {
             if (sessionItems == null)
             {
-                sessionItems = new SessionStateItemCollection();
+                sessionItems = new ThreadSafeSessionStateItemCollection();
             }
 
             if (staticObjects == null && context != null)

--- a/src/SessionStateModule/InProcSessionStateStoreAsync.cs
+++ b/src/SessionStateModule/InProcSessionStateStoreAsync.cs
@@ -439,7 +439,7 @@ namespace Microsoft.AspNet.SessionState
             {
                 if (SessionStateModuleAsync.AllowConcurrentRequestsPerSession)
                 {
-                    sessionItems = new ConcurrentSessionStateItemCollection();
+                    sessionItems = new ConcurrentNonSerializingSessionStateItemCollection();
                 }
                 else
                 {

--- a/src/SessionStateModule/InProcSessionStateStoreAsync.cs
+++ b/src/SessionStateModule/InProcSessionStateStoreAsync.cs
@@ -437,7 +437,7 @@ namespace Microsoft.AspNet.SessionState
         {
             if (sessionItems == null)
             {
-                sessionItems = new ThreadSafeSessionStateItemCollection();
+                sessionItems = new ConcurrentSessionStateItemCollection();
             }
 
             if (staticObjects == null && context != null)

--- a/src/SessionStateModule/InProcSessionStateStoreAsync.cs
+++ b/src/SessionStateModule/InProcSessionStateStoreAsync.cs
@@ -437,7 +437,14 @@ namespace Microsoft.AspNet.SessionState
         {
             if (sessionItems == null)
             {
-                sessionItems = new ConcurrentSessionStateItemCollection();
+                if (SessionStateModuleAsync.AllowConcurrentRequestsPerSession)
+                {
+                    sessionItems = new ConcurrentSessionStateItemCollection();
+                }
+                else
+                {
+                    sessionItems = new SessionStateItemCollection();
+                }
             }
 
             if (staticObjects == null && context != null)

--- a/src/SessionStateModule/Microsoft.AspNet.SessionState.SessionStateModule.csproj
+++ b/src/SessionStateModule/Microsoft.AspNet.SessionState.SessionStateModule.csproj
@@ -66,6 +66,7 @@
     </Compile>
     <Compile Include="SessionEventSource.cs" />
     <Compile Include="SessionOnEndTarget.cs" />
+    <Compile Include="SessionStateItemCollections.cs" />
     <Compile Include="SessionStateModuleAsync.cs" />
     <Compile Include="SessionStateStoreProviderAsyncBase.cs" />
     <Compile Include="TaskAsyncHelper.cs" />

--- a/src/SessionStateModule/Microsoft.AspNet.SessionState.SessionStateModule.csproj
+++ b/src/SessionStateModule/Microsoft.AspNet.SessionState.SessionStateModule.csproj
@@ -69,6 +69,7 @@
     <Compile Include="SessionStateItemCollections.cs" />
     <Compile Include="SessionStateModuleAsync.cs" />
     <Compile Include="SessionStateStoreProviderAsyncBase.cs" />
+    <Compile Include="StateSerializationUtil.cs" />
     <Compile Include="TaskAsyncHelper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SessionStateModule/Resources/SR.Designer.cs
+++ b/src/SessionStateModule/Resources/SR.Designer.cs
@@ -61,6 +61,15 @@ namespace Microsoft.AspNet.SessionState.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to serialize the session state. For out-of-proc session stores, ASP.NET will serialize the session state objects, and as a result non-serializable objects or MarshalByRef objects are not permitted..
+        /// </summary>
+        internal static string Cant_serialize_session_state {
+            get {
+                return ResourceManager.GetString("Cant_serialize_session_state", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error occured when reading config secion &apos;{0}&apos;..
         /// </summary>
         internal static string Error_Occured_Reading_Config_Secion {
@@ -84,6 +93,15 @@ namespace Microsoft.AspNet.SessionState.Resources {
         internal static string Invalid_session_custom_provider {
             get {
                 return ResourceManager.GetString("Invalid_session_custom_provider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The session state information is invalid and might be corrupted..
+        /// </summary>
+        internal static string Invalid_session_state {
+            get {
+                return ResourceManager.GetString("Invalid_session_state", resourceCulture);
             }
         }
         

--- a/src/SessionStateModule/Resources/SR.resx
+++ b/src/SessionStateModule/Resources/SR.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Cant_serialize_session_state" xml:space="preserve">
+    <value>Unable to serialize the session state. For out-of-proc session stores, ASP.NET will serialize the session state objects, and as a result non-serializable objects or MarshalByRef objects are not permitted.</value>
+  </data>
   <data name="Error_Occured_Reading_Config_Secion" xml:space="preserve">
     <value>Error occured when reading config secion '{0}'.</value>
   </data>
@@ -125,6 +128,9 @@
   </data>
   <data name="Invalid_session_custom_provider" xml:space="preserve">
     <value>The custom session state store provider name '{0}' is invalid.</value>
+  </data>
+  <data name="Invalid_session_state" xml:space="preserve">
+    <value>The session state information is invalid and might be corrupted.</value>
   </data>
   <data name="Missing_session_custom_provider" xml:space="preserve">
     <value>The custom session state store provider '{0}' is not found.</value>

--- a/src/SessionStateModule/SessionStateItemCollections.cs
+++ b/src/SessionStateModule/SessionStateItemCollections.cs
@@ -9,7 +9,7 @@ using ISessionStateItemCollection = System.Web.SessionState.ISessionStateItemCol
 namespace Microsoft.AspNet.SessionState
 {
     /// <summary>A collection of objects stored in session state. This class cannot be inherited.</summary>
-    public sealed class ThreadSafeSessionStateItemCollection : NameObjectCollectionBase, ISessionStateItemCollection, ICollection, IEnumerable
+    public sealed class ConcurrentSessionStateItemCollection : NameObjectCollectionBase, ISessionStateItemCollection, ICollection, IEnumerable
     {
         private static Hashtable s_immutableTypes;
 
@@ -110,7 +110,7 @@ namespace Microsoft.AspNet.SessionState
             }
         }
 
-        static ThreadSafeSessionStateItemCollection()
+        static ConcurrentSessionStateItemCollection()
         {
             s_immutableTypes = new Hashtable(19);
             Type type = typeof(string);
@@ -154,7 +154,7 @@ namespace Microsoft.AspNet.SessionState
         }
 
         /// <summary>Creates a new, empty <see cref="T:System.Web.SessionState.SessionStateItemCollection" /> object.</summary>
-        public ThreadSafeSessionStateItemCollection() : base(Misc.CaseInsensitiveInvariantKeyComparer)
+        public ConcurrentSessionStateItemCollection() : base(Misc.CaseInsensitiveInvariantKeyComparer)
         {
         }
 

--- a/src/SessionStateModule/SessionStateModuleAsync.cs
+++ b/src/SessionStateModule/SessionStateModuleAsync.cs
@@ -102,6 +102,12 @@ namespace Microsoft.AspNet.SessionState
                 return s_configMode;
             }
         }
+
+        /// <summary>
+        /// Indicates whether the session state module is configured to optimistically allow concurrent requests
+        /// </summary>
+        public static bool AllowConcurrentRequestsPerSession => AppSettings.AllowConcurrentRequestsPerSession;
+
         /// <summary>
         /// Initialize the module
         /// </summary>

--- a/src/SessionStateModule/StateSerializationUtil.cs
+++ b/src/SessionStateModule/StateSerializationUtil.cs
@@ -1,0 +1,315 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See the License.txt file in the project root for full license information.
+
+namespace Microsoft.AspNet.SessionState
+{
+    using Microsoft.AspNet.SessionState.Resources;
+    using System;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using System.Web;
+    using System.Web.SessionState;
+
+    internal static class StateSerializationUtil
+    {
+        enum TypeID : byte
+        {
+            String = 1,
+            Int32,
+            Boolean,
+            DateTime,
+            Decimal,
+            Byte,
+            Char,
+            Single,
+            Double,
+            SByte,
+            Int16,
+            Int64,
+            UInt16,
+            UInt32,
+            UInt64,
+            TimeSpan,
+            Guid,
+            IntPtr,
+            UIntPtr,
+            Object,
+            Null,
+        }
+
+        internal static Object ReadValueFromStream(BinaryReader reader)
+        {
+            TypeID id;
+            Object value = null;
+
+            id = (TypeID)reader.ReadByte();
+            switch (id)
+            {
+                case TypeID.String:
+                    value = reader.ReadString();
+                    break;
+
+                case TypeID.Int32:
+                    value = reader.ReadInt32();
+                    break;
+
+                case TypeID.Boolean:
+                    value = reader.ReadBoolean();
+                    break;
+
+                case TypeID.DateTime:
+                    value = new DateTime(reader.ReadInt64());
+                    break;
+
+                case TypeID.Decimal:
+                    {
+                        int[] bits = new int[4];
+                        for (int i = 0; i < 4; i++)
+                        {
+                            bits[i] = reader.ReadInt32();
+                        }
+
+                        value = new Decimal(bits);
+                    }
+                    break;
+
+                case TypeID.Byte:
+                    value = reader.ReadByte();
+                    break;
+
+                case TypeID.Char:
+                    value = reader.ReadChar();
+                    break;
+
+                case TypeID.Single:
+                    value = reader.ReadSingle();
+                    break;
+
+                case TypeID.Double:
+                    value = reader.ReadDouble();
+                    break;
+
+                case TypeID.SByte:
+                    value = reader.ReadSByte();
+                    break;
+
+                case TypeID.Int16:
+                    value = reader.ReadInt16();
+                    break;
+
+                case TypeID.Int64:
+                    value = reader.ReadInt64();
+                    break;
+
+                case TypeID.UInt16:
+                    value = reader.ReadUInt16();
+                    break;
+
+                case TypeID.UInt32:
+                    value = reader.ReadUInt32();
+                    break;
+
+                case TypeID.UInt64:
+                    value = reader.ReadUInt64();
+                    break;
+
+                case TypeID.TimeSpan:
+                    value = new TimeSpan(reader.ReadInt64());
+                    break;
+
+                case TypeID.Guid:
+                    {
+                        byte[] bits = reader.ReadBytes(16);
+                        value = new Guid(bits);
+                    }
+                    break;
+
+                case TypeID.IntPtr:
+                    if (IntPtr.Size == 4)
+                    {
+                        value = new IntPtr(reader.ReadInt32());
+                    }
+                    else
+                    {
+                        Debug.Assert(IntPtr.Size == 8);
+                        value = new IntPtr(reader.ReadInt64());
+                    }
+                    break;
+
+                case TypeID.UIntPtr:
+                    if (UIntPtr.Size == 4)
+                    {
+                        value = new UIntPtr(reader.ReadUInt32());
+                    }
+                    else
+                    {
+                        Debug.Assert(UIntPtr.Size == 8);
+                        value = new UIntPtr(reader.ReadUInt64());
+                    }
+                    break;
+
+                case TypeID.Object:
+                    BinaryFormatter formatter = new BinaryFormatter();
+                    if (SessionStateUtility.SerializationSurrogateSelector != null)
+                    {
+                        formatter.SurrogateSelector = SessionStateUtility.SerializationSurrogateSelector;
+                    }
+                    value = formatter.Deserialize(reader.BaseStream);
+                    break;
+
+                case TypeID.Null:
+                    value = null;
+                    break;
+            }
+
+            return value;
+        }
+
+        internal static void WriteValueToStream(Object value, BinaryWriter writer)
+        {
+            if (value == null)
+            {
+                writer.Write((byte)TypeID.Null);
+            }
+            else if (value is String)
+            {
+                writer.Write((byte)TypeID.String);
+                writer.Write((String)value);
+            }
+            else if (value is Int32)
+            {
+                writer.Write((byte)TypeID.Int32);
+                writer.Write((Int32)value);
+            }
+            else if (value is Boolean)
+            {
+                writer.Write((byte)TypeID.Boolean);
+                writer.Write((Boolean)value);
+            }
+            else if (value is DateTime)
+            {
+                writer.Write((byte)TypeID.DateTime);
+                writer.Write(((DateTime)value).Ticks);
+            }
+            else if (value is Decimal)
+            {
+                writer.Write((byte)TypeID.Decimal);
+                int[] bits = Decimal.GetBits((Decimal)value);
+                for (int i = 0; i < 4; i++)
+                {
+                    writer.Write((int)bits[i]);
+                }
+            }
+            else if (value is Byte)
+            {
+                writer.Write((byte)TypeID.Byte);
+                writer.Write((byte)value);
+            }
+            else if (value is Char)
+            {
+                writer.Write((byte)TypeID.Char);
+                writer.Write((char)value);
+            }
+            else if (value is Single)
+            {
+                writer.Write((byte)TypeID.Single);
+                writer.Write((float)value);
+            }
+            else if (value is Double)
+            {
+                writer.Write((byte)TypeID.Double);
+                writer.Write((double)value);
+            }
+            else if (value is SByte)
+            {
+                writer.Write((byte)TypeID.SByte);
+                writer.Write((SByte)value);
+            }
+            else if (value is Int16)
+            {
+                writer.Write((byte)TypeID.Int16);
+                writer.Write((short)value);
+            }
+            else if (value is Int64)
+            {
+                writer.Write((byte)TypeID.Int64);
+                writer.Write((long)value);
+            }
+            else if (value is UInt16)
+            {
+                writer.Write((byte)TypeID.UInt16);
+                writer.Write((UInt16)value);
+            }
+            else if (value is UInt32)
+            {
+                writer.Write((byte)TypeID.UInt32);
+                writer.Write((UInt32)value);
+            }
+            else if (value is UInt64)
+            {
+                writer.Write((byte)TypeID.UInt64);
+                writer.Write((UInt64)value);
+            }
+            else if (value is TimeSpan)
+            {
+                writer.Write((byte)TypeID.TimeSpan);
+                writer.Write(((TimeSpan)value).Ticks);
+            }
+            else if (value is Guid)
+            {
+                writer.Write((byte)TypeID.Guid);
+                Guid guid = (Guid)value;
+                byte[] bits = guid.ToByteArray();
+                writer.Write(bits);
+            }
+            else if (value is IntPtr)
+            {
+                writer.Write((byte)TypeID.IntPtr);
+                IntPtr v = (IntPtr)value;
+                if (IntPtr.Size == 4)
+                {
+                    writer.Write((Int32)v.ToInt32());
+                }
+                else
+                {
+                    Debug.Assert(IntPtr.Size == 8);
+                    writer.Write((Int64)v.ToInt64());
+                }
+            }
+            else if (value is UIntPtr)
+            {
+                writer.Write((byte)TypeID.UIntPtr);
+                UIntPtr v = (UIntPtr)value;
+                if (UIntPtr.Size == 4)
+                {
+                    writer.Write((UInt32)v.ToUInt32());
+                }
+                else
+                {
+                    Debug.Assert(UIntPtr.Size == 8);
+                    writer.Write((UInt64)v.ToUInt64());
+                }
+            }
+            else
+            {
+                writer.Write((byte)TypeID.Object);
+                BinaryFormatter formatter = new BinaryFormatter();
+                if (SessionStateUtility.SerializationSurrogateSelector != null)
+                {
+                    formatter.SurrogateSelector = SessionStateUtility.SerializationSurrogateSelector;
+                }
+                try
+                {
+                    formatter.Serialize(writer.BaseStream, value);
+                }
+                catch (Exception innerException)
+                {
+                    HttpException outerException = new HttpException(String.Format(CultureInfo.CurrentCulture, SR.Cant_serialize_session_state), innerException);
+                    throw outerException;
+                }
+            }
+        }
+    }
+}

--- a/src/SessionStateModule/ThreadSafeSessionStateItemCollection.cs
+++ b/src/SessionStateModule/ThreadSafeSessionStateItemCollection.cs
@@ -1,0 +1,297 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.IO;
+using HttpRuntime = System.Web.HttpRuntime;
+using ISessionStateItemCollection = System.Web.SessionState.ISessionStateItemCollection;
+
+namespace Microsoft.AspNet.SessionState
+{
+    /// <summary>A collection of objects stored in session state. This class cannot be inherited.</summary>
+    public sealed class ThreadSafeSessionStateItemCollection : NameObjectCollectionBase, ISessionStateItemCollection, ICollection, IEnumerable
+    {
+        private static Hashtable s_immutableTypes;
+
+        private const int NO_NULL_KEY = -1;
+
+        private const int SIZE_OF_INT32 = 4;
+
+        private bool _dirty;
+
+        private KeyedCollection _serializedItems;
+
+        private Stream _stream;
+
+        private int _iLastOffset;
+
+        private object _serializedItemsLock = new object();
+
+        /// <summary>Gets or sets a value indicating whether the collection has been marked as changed.</summary>
+        /// <returns>true if the <see cref="T:System.Web.SessionState.SessionStateItemCollection" /> contents have been changed; otherwise, false.</returns>
+        public bool Dirty
+        {
+            get
+            {
+                return this._dirty;
+            }
+            set
+            {
+                this._dirty = value;
+            }
+        }
+
+        /// <summary>Gets or sets a value in the collection by name.</summary>
+        /// <returns>The value in the collection with the specified name. If the specified key is not found, attempting to get it returns null, and attempting to set it creates a new element using the specified key.</returns>
+        /// <param name="name">The key name of the value in the collection.</param>
+        public object this[string name]
+        {
+            get
+            {
+                lock (this._serializedItemsLock)
+                {
+                    //this.DeserializeItem(name, true);
+                    object obj = base.BaseGet(name);
+                    if (obj != null && !IsImmutable(obj))
+                    {
+                        this._dirty = true;
+                    }
+                    return obj;
+                }
+            }
+            set
+            {
+                lock (this._serializedItemsLock)
+                {
+                    //this.MarkItemDeserialized(name);
+                    base.BaseSet(name, value);
+                    this._dirty = true;
+                }
+            }
+        }
+
+        /// <summary>Gets or sets a value in the collection by numerical index.</summary>
+        /// <returns>The value in the collection stored at the specified index. If the specified key is not found, attempting to get it returns null, and attempting to set it creates a new element using the specified key.</returns>
+        /// <param name="index">The numerical index of the value in the collection.</param>
+        public object this[int index]
+        {
+            get
+            {
+                lock (this._serializedItemsLock)
+                {
+                    //this.DeserializeItem(index);
+                    object obj = base.BaseGet(index);
+                    if (obj != null && !IsImmutable(obj))
+                    {
+                        this._dirty = true;
+                    }
+                    return obj;
+                }
+            }
+            set
+            {
+                lock (this._serializedItemsLock)
+                {
+                    //this.MarkItemDeserialized(index);
+                    base.BaseSet(index, value);
+                    this._dirty = true;
+                }
+            }
+        }
+
+        /// <summary>Gets a collection of the variable names for all values stored in the collection.</summary>
+        /// <returns>The <see cref="T:System.Collections.Specialized.NameObjectCollectionBase.KeysCollection" /> collection that contains all the collection keys. </returns>
+        public override NameObjectCollectionBase.KeysCollection Keys
+        {
+            get
+            {
+                //this.DeserializeAllItems();
+                return base.Keys;
+            }
+        }
+
+        static ThreadSafeSessionStateItemCollection()
+        {
+            s_immutableTypes = new Hashtable(19);
+            Type type = typeof(string);
+            s_immutableTypes.Add(type, type);
+            type = typeof(int);
+            s_immutableTypes.Add(type, type);
+            type = typeof(bool);
+            s_immutableTypes.Add(type, type);
+            type = typeof(DateTime);
+            s_immutableTypes.Add(type, type);
+            type = typeof(decimal);
+            s_immutableTypes.Add(type, type);
+            type = typeof(byte);
+            s_immutableTypes.Add(type, type);
+            type = typeof(char);
+            s_immutableTypes.Add(type, type);
+            type = typeof(float);
+            s_immutableTypes.Add(type, type);
+            type = typeof(double);
+            s_immutableTypes.Add(type, type);
+            type = typeof(sbyte);
+            s_immutableTypes.Add(type, type);
+            type = typeof(short);
+            s_immutableTypes.Add(type, type);
+            type = typeof(long);
+            s_immutableTypes.Add(type, type);
+            type = typeof(ushort);
+            s_immutableTypes.Add(type, type);
+            type = typeof(uint);
+            s_immutableTypes.Add(type, type);
+            type = typeof(ulong);
+            s_immutableTypes.Add(type, type);
+            type = typeof(TimeSpan);
+            s_immutableTypes.Add(type, type);
+            type = typeof(Guid);
+            s_immutableTypes.Add(type, type);
+            type = typeof(IntPtr);
+            s_immutableTypes.Add(type, type);
+            type = typeof(UIntPtr);
+            s_immutableTypes.Add(type, type);
+        }
+
+        /// <summary>Creates a new, empty <see cref="T:System.Web.SessionState.SessionStateItemCollection" /> object.</summary>
+        public ThreadSafeSessionStateItemCollection() : base(Misc.CaseInsensitiveInvariantKeyComparer)
+        {
+        }
+
+        /// <summary>Removes all values and keys from the session-state collection.</summary>
+        public void Clear()
+        {
+            lock (this._serializedItemsLock)
+            {
+                if (this._serializedItems != null)
+                {
+                    this._serializedItems.Clear();
+                }
+                base.BaseClear();
+                this._dirty = true;
+            }
+        }
+
+        /// <summary>Returns an enumerator that can be used to read all the key names in the collection.</summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> that can iterate through the variable names in the session-state collection.</returns>
+        public override IEnumerator GetEnumerator()
+        {
+            //this.DeserializeAllItems();
+            return base.GetEnumerator();
+        }
+
+        internal static bool IsImmutable(object o)
+        {
+            return s_immutableTypes[o.GetType()] != null;
+        }
+
+        /// <summary>Deletes an item from the collection.</summary>
+        /// <param name="name">The name of the item to delete from the collection. </param>
+        public void Remove(string name)
+        {
+            lock (this._serializedItemsLock)
+            {
+                if (this._serializedItems != null)
+                {
+                    this._serializedItems.Remove(name);
+                }
+                base.BaseRemove(name);
+                this._dirty = true;
+            }
+        }
+
+        /// <summary>Deletes an item at a specified index from the collection.</summary>
+        /// <param name="index">The index of the item to remove from the collection. </param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        ///   <paramref name="index" /> is less than zero.- or -<paramref name="index" /> is equal to or greater than <see cref="P:System.Collections.ICollection.Count" />.</exception>
+        public void RemoveAt(int index)
+        {
+            lock (this._serializedItemsLock)
+            {
+                if (this._serializedItems != null && index < this._serializedItems.Count)
+                {
+                    this._serializedItems.RemoveAt(index);
+                }
+                base.BaseRemoveAt(index);
+                this._dirty = true;
+            }
+        }
+
+        private class KeyedCollection : NameObjectCollectionBase
+        {
+            internal object this[string name]
+            {
+                get
+                {
+                    return base.BaseGet(name);
+                }
+                set
+                {
+                    if (base.BaseGet(name) == null && value == null)
+                    {
+                        return;
+                    }
+                    base.BaseSet(name, value);
+                }
+            }
+
+            internal object this[int index]
+            {
+                get
+                {
+                    return base.BaseGet(index);
+                }
+            }
+
+            internal KeyedCollection(int count) : base(count, Misc.CaseInsensitiveInvariantKeyComparer)
+            {
+            }
+
+            internal void Clear()
+            {
+                base.BaseClear();
+            }
+
+            internal bool ContainsKey(string name)
+            {
+                return base.BaseGet(name) != null;
+            }
+
+            internal string GetKey(int index)
+            {
+                return base.BaseGetKey(index);
+            }
+
+            internal void Remove(string name)
+            {
+                base.BaseRemove(name);
+            }
+
+            internal void RemoveAt(int index)
+            {
+                base.BaseRemoveAt(index);
+            }
+        }
+
+        internal sealed class Misc
+        {
+            private static StringComparer s_caseInsensitiveInvariantKeyComparer;
+
+            internal static StringComparer CaseInsensitiveInvariantKeyComparer
+            {
+                get
+                {
+                    if (Misc.s_caseInsensitiveInvariantKeyComparer == null)
+                    {
+                        Misc.s_caseInsensitiveInvariantKeyComparer = StringComparer.Create(CultureInfo.InvariantCulture, true);
+                    }
+                    return Misc.s_caseInsensitiveInvariantKeyComparer;
+                }
+            }
+
+            public Misc()
+            {
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.SessionState.SqlSessionStateProviderAsync.Test/SqlSessionStateAsyncProviderTest.cs
+++ b/test/Microsoft.AspNet.SessionState.SqlSessionStateProviderAsync.Test/SqlSessionStateAsyncProviderTest.cs
@@ -7,6 +7,7 @@ namespace Microsoft.AspNet.SessionState.SqlSessionStateAsyncProvider.Test
     using Microsoft.Data.SqlClient;
     using Moq;
     using System;
+    using System.Collections.Generic;
     using System.Collections.Specialized;
     using System.Configuration;
     using System.IO;
@@ -228,12 +229,18 @@ namespace Microsoft.AspNet.SessionState.SqlSessionStateAsyncProvider.Test
             Assert.Equal(TestTimeout, store.Timeout);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Serialize_And_Deserialized_SessionStateStoreData_RoundTrip_Should_Work(bool enableCompression)
+        public static IEnumerable<object[]> SerializeSessionData()
         {
-            var sessionCollection = new SessionStateItemCollection();
+            yield return new object[] { true, new SessionStateItemCollection() };
+            yield return new object[] { true, new SessionStateItemCollection() };
+            yield return new object[] { false, new ConcurrentSessionStateItemCollection() };
+            yield return new object[] { false, new ConcurrentSessionStateItemCollection() };
+        }
+
+        [Theory]
+        [MemberData(nameof(SerializeSessionData))]
+        public void Serialize_And_Deserialized_SessionStateStoreData_RoundTrip_Should_Work(bool enableCompression, ISessionStateItemCollection sessionCollection)
+        {
             var now = DateTime.UtcNow;
             sessionCollection["test1"] = "test1";
             sessionCollection["test2"] = now;


### PR DESCRIPTION
Started with PR #99 from @mellamokb. Decided to fill out the concept to apply to all our async providers that might work in `AllowConcurrentRequestsPerSession` mode.

Original PR description:
> Added new ThreadSafeSessionStateItemCollection to replace built-in Microsoft one. This fixes the race condition in the indexers. Also commented out all serialization since this is intended to only be used with the in-memory session, so serialization is not necessary.

This pull request introduces significant changes to the session state management in the `CosmosDBSessionStateProviderAsync` and `SqlSessionStateProviderAsync` classes, focusing on support for concurrent requests and improved serialization. The most important changes include the addition of new helper methods for creating and serializing session state item collections, as well as updates to existing methods to utilize these new helpers.
