### PR TITLE
Added GetDeterministicHashCode for app ID suffix

### DIFF
--- a/src/SqlSessionStateProviderAsync/Microsoft.AspNet.SessionState.SqlSessionStateProviderAsync.csproj
+++ b/src/SqlSessionStateProviderAsync/Microsoft.AspNet.SessionState.SqlSessionStateProviderAsync.csproj
@@ -77,6 +77,7 @@
     <Compile Include="SqlFxCompatSessionStateRepository.cs" />
     <Compile Include="SqlSessionStateRepository.cs" />
     <Compile Include="SqlSessionStateRepositoryUtil.cs" />
+    <Compile Include="StringExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\SR.resx">

--- a/src/SqlSessionStateProviderAsync/SqlSessionStateProviderAsync.cs
+++ b/src/SqlSessionStateProviderAsync/SqlSessionStateProviderAsync.cs
@@ -125,7 +125,7 @@ namespace Microsoft.AspNet.SessionState
 
                         var appId = AppId ?? HttpRuntime.AppDomainAppId;
                         Debug.Assert(appId != null);
-                        s_appSuffix = appId.GetHashCode().ToString("X8", CultureInfo.InvariantCulture);
+                        s_appSuffix = appId.GetDeterministicHashCode().ToString("X8", CultureInfo.InvariantCulture);
 
                         s_oneTimeInited = true;
                     }

--- a/src/SqlSessionStateProviderAsync/StringExtensions.cs
+++ b/src/SqlSessionStateProviderAsync/StringExtensions.cs
@@ -1,0 +1,29 @@
+﻿namespace Microsoft.AspNet.SessionState
+{
+    internal static class StringExtensions
+    {
+        //============================================================================ robs ==
+        // This is to replace the call to GetHashCode() when appending AppId to the session id.
+        // Using GetHashCode() is not deterministic and can cause problems when used externally (e.g in SQL)
+        // Credit: https://andrewlock.net/why-is-string-gethashcode-different-each-time-i-run-my-program-in-net-core/
+        //====================================================================== 2023-07-21 ==
+        internal static int GetDeterministicHashCode(this string str)
+        {
+            unchecked
+            {
+                int hash1 = (5381 << 16) + 5381;
+                int hash2 = hash1;
+
+                for (int i = 0; i < str.Length; i += 2)
+                {
+                    hash1 = ((hash1 << 5) + hash1) ^ str[i];
+                    if (i == str.Length - 1)
+                        break;
+                    hash2 = ((hash2 << 5) + hash2) ^ str[i + 1];
+                }
+
+                return hash1 + (hash2 * 1566083941);
+            }
+        }
+    }
+}


### PR DESCRIPTION
`SqlSessionStateProviderAsync` follows the lead of the in-box SQL session state provider and uses an AppID to keep session data from different applications separate. When calculating the AppID, they both append a hash code to the ID. This hash code should be deterministic so session data can be retrieved by the same app across various lifecycle events.

Originally investigated and proposed by @robs in PR #97 - this part of the larger proposal is definitely a change we would like to incorporate.