### PR TITLE
Use a reasonable retry interval for In-Memory SQL.

### DIFF
--- a/src/SqlSessionStateProviderAsync/SqlInMemoryTableSessionStateRepository.cs
+++ b/src/SqlSessionStateProviderAsync/SqlInMemoryTableSessionStateRepository.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.SessionState
     class SqlInMemoryTableSessionStateRepository : ISqlSessionStateRepository
     {
         private const int DEFAULT_RETRY_NUM = 10;
-        private const int DEFAULT_RETRY_INERVAL = 1;
+        private const int DEFAULT_RETRY_INERVAL = 200;
         private readonly string SessionTableName = "ASPNetSessionState_InMem";
 
         private int _retryIntervalMilSec;


### PR DESCRIPTION
InMemory OLTP tables should be much lower latency than standard tables. But even still, a 1ms retry interval is awfully fast. This might help with #109?