### PR TITLE
Switch SqlDataReader.ReadAsync to SqlDataReader.Read in SqlSessionStateProviderAsync because of a known performance issue with reading large data asynchronously

### DIFF
--- a/src/SqlSessionStateProviderAsync/SqlSessionStateRepository.cs
+++ b/src/SqlSessionStateProviderAsync/SqlSessionStateRepository.cs
@@ -492,11 +492,13 @@ namespace Microsoft.AspNet.SessionState
             {
                 using (var reader = await SqlSessionStateRepositoryUtil.SqlExecuteReaderWithRetryAsync(connection, cmd, CanRetryAsync))
                 {
-                    if (await reader.ReadAsync())
+                    // use the synchronous versions of Read and GetFieldValue because of performance issues with
+                    // large data described here: https://github.com/dotnet/SqlClient/issues/593
+                    if (reader.Read())
                     {
                         // Varbinary(max) should not be returned in an output parameter
                         // Read the returned dataset consisting of SessionItemLong if found
-                        buf = await reader.GetFieldValueAsync<byte[]>(0);
+                        buf = reader.GetFieldValue<byte[]>(0);
                     }
                 }
 


### PR DESCRIPTION
In one project, we suddenly encountered a major performance issue. The problem arose after deploying a new release. We spent a considerable amount of time searching for the cause within our release. Ultimately, the issue was traced back to the `SqlSessionStateProviderAsync`.

Since we use Application Insights for logging and tracing, we observed unusual gaps after reading the ASP.NET session. Initially, it appeared as if the session had already been read, and then the gap occurred. After extensive analysis and significantly extending the `SqlSessionStateProviderAsync` with telemetry, we (my colleague @opneu and I) discovered that time was being lost within this session provider implementation.

The calls to `SqlDataReader.ReadAsync` and `SqlDataReader.GetFieldValueAsync` within `SqlSessionStateProviderAsync` were taking an extremely long time. Further research led me to this ticket:

https://github.com/dotnet/SqlClient/issues/593

After switching to the synchronous versions of the aforementioned methods, the session could be loaded again within just a few milliseconds.

We attribute the sudden occurrence of the massive performance problems to the fact that, with the new release, we are writing more to the ASP.NET session than before the release.

Looking back at past logs, we can say that we were not only able to resolve the new, truly severe performance issue, but the average access times to the ASP.NET session have also been faster since the fix.